### PR TITLE
Fixes bug which was causing first element to be repeated when a ol/ul was rendered

### DIFF
--- a/laser-native-editor/src/main/java/com/github/irshulx/Components/HTMLExtensions.java
+++ b/laser-native-editor/src/main/java/com/github/irshulx/Components/HTMLExtensions.java
@@ -89,6 +89,7 @@ public class HTMLExtensions {
             String text = getHtmlSpan(li);
             TableLayout layout = editorCore.getListItemExtensions().insertList(editorCore.getParentChildCount(), isOrdered, text);
             for (int i = 1; i < element.children().size(); i++) {
+                li = element.child(i);
                 text = getHtmlSpan(li);
                 editorCore.getListItemExtensions().AddListItem(layout, isOrdered, text);
             }


### PR DESCRIPTION
Fixes bug 

- https://github.com/irshuLx/Android-WYSIWYG-Editor/issues/13#issue 
- https://github.com/irshuLx/Android-WYSIWYG-Editor/issues/12

Cause: Value of the text to be rendered was not updated in the loop. 