### PR TITLE
Fix ClassCastException

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The editor is built, so that every part of the design have been exposed and is a
 Usage
 -------------------
 
-For a complete overview of the implementation, please take a look at [EditorTestActivity.java](https://github.com/irshuLx/laser-native-editor/blob/master/app/src/main/java/com/example/mkallingal/qapp/EditorTestActivity.java)
+For a complete overview of the implementation, please take a look at [EditorTestActivity.java](https://github.com/irshuLx/Android-WYSIWYG-Editor/blob/master/app/src/main/java/com/github/irshulx/qapp/EditorTestActivity.java)
 
 **Layout XML**
 

--- a/laser-native-editor/src/main/java/com/github/irshulx/EditorCore.java
+++ b/laser-native-editor/src/main/java/com/github/irshulx/EditorCore.java
@@ -52,7 +52,6 @@ public class EditorCore extends LinearLayout {
     */
     private final String SHAREDPREFERENCE = "QA";
     private Context __context;
-    private Activity __activity;
     protected LinearLayout __parentView;
     private RenderType __renderType;
     private Resources __resources;
@@ -72,7 +71,6 @@ public class EditorCore extends LinearLayout {
     public EditorCore(Context _context, AttributeSet attrs) {
         super(_context, attrs);
         this.__context = _context;
-        this.__activity = (Activity) _context;
         this.setOrientation(VERTICAL);
         initialize(_context, attrs);
     }
@@ -105,7 +103,7 @@ public class EditorCore extends LinearLayout {
      * @return
      */
     public Activity getActivity() {
-        return this.__activity;
+        return (Activity) this.__context;
     }
 
     /**


### PR DESCRIPTION
Closes #1 

Problem:

```
java.lang.ClassCastException: com.android.layoutlib.bridge.android.BridgeContext cannot be cast to android.app.Activity
	at com.github.irshulx.EditorCore.<init>(EditorCore.java:75)
	at com.github.irshulx.Editor.<init>(Editor.java:33)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.jetbrains.android.uipreview.ViewLoader.createNewInstance(ViewLoader.java:481)
	at org.jetbrains.android.uipreview.ViewLoader.loadClass(ViewLoader.java:264)
	at org.jetbrains.android.uipreview.ViewLoader.loadView(ViewLoader.java:222)
	at com.android.tools.idea.rendering.LayoutlibCallbackImpl.loadView(LayoutlibCallbackImpl.java:211)
	at android.view.BridgeInflater.loadCustomView(BridgeInflater.java:337)
	at android.view.BridgeInflater.loadCustomView(BridgeInflater.java:348)
	at android.view.BridgeInflater.createViewFromTag(BridgeInflater.java:248)
	at android.view.LayoutInflater.createViewFromTag(LayoutInflater.java:730)
	at android.view.LayoutInflater.rInflate_Original(LayoutInflater.java:863)
	at android.view.LayoutInflater_Delegate.rInflate(LayoutInflater_Delegate.java:72)
	at android.view.LayoutInflater.rInflate(LayoutInflater.java:837)
	at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:824)
	at android.view.LayoutInflater.rInflate_Original(LayoutInflater.java:866)
	at android.view.LayoutInflater_Delegate.rInflate(LayoutInflater_Delegate.java:72)
	at android.view.LayoutInflater.rInflate(LayoutInflater.java:837)
	at android.view.LayoutInflater.rInflateChildren(LayoutInflater.java:824)
	at android.view.LayoutInflater.inflate(LayoutInflater.java:515)
	at android.view.LayoutInflater.inflate(LayoutInflater.java:394)
	at com.android.layoutlib.bridge.impl.RenderSessionImpl.inflate(RenderSessionImpl.java:325)
	at com.android.layoutlib.bridge.Bridge.createSession(Bridge.java:384)
	at com.android.tools.idea.layoutlib.LayoutLibrary.createSession(LayoutLibrary.java:193)
	at com.android.tools.idea.rendering.RenderTask.createRenderSession(RenderTask.java:547)
	at com.android.tools.idea.rendering.RenderTask.lambda$inflate$3(RenderTask.java:681)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

Cause:

    this.__activity = (Activity) _context;

Consequences: Prevents rendering in the layout preview

Since the __activity field is private, and (from what I can tell) not used anywhere directly (aside from the getter), I removed the field and made the getActivity method return `__context` cast as Activity. This should be able to prevent rendering failures and close #1.