### PR TITLE
Updated Bold ImageButton attributes to match others

### DIFF
--- a/laser-native-editor/src/main/res/layout/editor_toolbar_linearlayout_horizontal.xml
+++ b/laser-native-editor/src/main/res/layout/editor_toolbar_linearlayout_horizontal.xml
@@ -43,9 +43,11 @@
 
     <ImageButton
         android:id="@+id/action_bold"
-        android:layout_width="16dp"
-        android:layout_height="16dp"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
         android:background="@android:color/transparent"
+        android:maxHeight="20dp"
+        android:maxWidth="20dp"
         android:src="@drawable/icon_bold" />
 
     <ImageButton


### PR DESCRIPTION
Bold ImageButton width, height, max width and max height weren't matching other image buttons causing it to go slightly askew.