### PR TITLE
Updated InputExtensions#getTypeface to use contentTypeface map for required typeface

### DIFF
--- a/laser-native-editor/src/main/java/com/github/irshulx/Components/InputExtensions.java
+++ b/laser-native-editor/src/main/java/com/github/irshulx/Components/InputExtensions.java
@@ -674,7 +674,7 @@ public class InputExtensions extends EditorComponent {
         }
         if (mode == HEADING && !headingTypeface.containsKey(style)) {
             throw new IllegalArgumentException("the provided fonts for heading is missing the varient for this style. Please checkout the documentation on adding custom fonts.");
-        } else if (mode == CONTENT && !headingTypeface.containsKey(style)) {
+        } else if (mode == CONTENT && !contentTypeface.containsKey(style)) {
             throw new IllegalArgumentException("the provided fonts for content is missing the varient for this style. Please checkout the documentation on adding custom fonts.");
         }
         if (mode == HEADING) {


### PR DESCRIPTION
Fix minor issue in `InputExtensions`

The library was attempting to load content typefaces from the header typefaces map