### PR TITLE
update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Download
 ------------
 gradle:
 
-    compile 'com.github.irshulx:laser-native-editor:3.0.3'
+    implementation 'com.github.irshulx:laser-native-editor:3.0.3'
 
 or maven:
 


### PR DESCRIPTION
The `compile` is deprecated, so have changed it to `implementation`